### PR TITLE
Adapt to support more Linux distributions for opening TensorBoard

### DIFF
--- a/gops/utils/tensorboard_setup.py
+++ b/gops/utils/tensorboard_setup.py
@@ -53,7 +53,7 @@ def start_tensorboard(logdir, port=DEFAULT_TB_PORT):
 
     sys_name = platform.system()
     if sys_name == "Linux":
-        cmd_line = "gnome-terminal -- tensorboard --logdir {} --port {}".format(
+        cmd_line = "tensorboard --logdir {} --port {} &".format(
             logdir, port
         )
     elif sys_name == "Windows":
@@ -100,7 +100,7 @@ def get_pids_windows(port):
 def kill_pids_linux(pids):
     for pid in pids:
         try:
-            os.kill(int(pid), signal.SIGINT)
+            os.kill(int(pid), signal.SIGTERM)
         except:
             pass
 


### PR DESCRIPTION
I am using the Manjaro-KDE system on Arch Linux, and I encountered the error `sh: line 1: gnome-terminal: command not found` every time I run the code under `example_train`. I eventually traced it back to this line in the code: https://github.com/Intelligent-Driving-Laboratory/GOPS/blob/5c34a0408c10f6997b45b8817846ac3326c17a87/gops/utils/tensorboard_setup.py#L56, where the `gnome-terminal` command is used. 
However, this is not suitable for non-GNOME desktop environments. I suggest modifying it to run in the background so that it's not limited to running exclusively on a GNOME desktop.